### PR TITLE
allow only active members to transfer money

### DIFF
--- a/bin/bot/src/discord/slash/bank.rs
+++ b/bin/bot/src/discord/slash/bank.rs
@@ -4,7 +4,11 @@ use serenity::{
     client::Context,
 };
 use synixe_events::gear::db::Response;
-use synixe_meta::discord::{channel::LOG, role::{ACTIVE, JUNIOR, MEMBER, STAFF}, BRODSKY, GUILD};
+use synixe_meta::discord::{
+    channel::LOG,
+    role::{ACTIVE, JUNIOR, MEMBER, STAFF},
+    BRODSKY, GUILD,
+};
 use synixe_proc::events_request_2;
 
 use crate::{discord::interaction::Interaction, get_option, get_option_user};

--- a/bin/bot/src/discord/slash/bank.rs
+++ b/bin/bot/src/discord/slash/bank.rs
@@ -4,7 +4,7 @@ use serenity::{
     client::Context,
 };
 use synixe_events::gear::db::Response;
-use synixe_meta::discord::{channel::LOG, role::STAFF, BRODSKY, GUILD};
+use synixe_meta::discord::{channel::LOG, role::{ACTIVE, JUNIOR, MEMBER, STAFF}, BRODSKY, GUILD};
 use synixe_proc::events_request_2;
 
 use crate::{discord::interaction::Interaction, get_option, get_option_user};
@@ -128,7 +128,7 @@ async fn balance(
         .await
 }
 
-#[allow(clippy::cast_possible_truncation)]
+#[allow(clippy::cast_possible_truncation, clippy::too_many_lines)]
 async fn transfer(
     ctx: &Context,
     command: &CommandInteraction,
@@ -139,6 +139,20 @@ async fn transfer(
     let Some(user) = get_option_user!(options, "member") else {
         return interaction.reply("Invalid member").await;
     };
+
+    super::requires_roles(
+        command.user.id,
+        &[JUNIOR, MEMBER, ACTIVE],
+        &command
+            .member
+            .as_ref()
+            .expect("member should always exist on guild commands")
+            .roles,
+        ShouldAsk::Deny,
+        &mut interaction,
+    )
+    .await?;
+
     if user != &synixe_meta::discord::BRODSKY && GUILD.member(&ctx, user).await?.user.bot {
         return interaction.reply("You can't transfer money to a bot").await;
     }

--- a/bin/bot/src/discord/slash/bank.rs
+++ b/bin/bot/src/discord/slash/bank.rs
@@ -152,7 +152,7 @@ async fn transfer(
             .as_ref()
             .expect("member should always exist on guild commands")
             .roles,
-        ShouldAsk::Deny,
+        ShouldAsk::Yes(("bank transfer", options)),
         &mut interaction,
     )
     .await?;

--- a/bin/bot/src/discord/slash/bank.rs
+++ b/bin/bot/src/discord/slash/bank.rs
@@ -146,7 +146,7 @@ async fn transfer(
 
     super::requires_roles(
         command.user.id,
-        &[JUNIOR, MEMBER, ACTIVE],
+        &[ACTIVE],
         &command
             .member
             .as_ref()

--- a/bin/bot/src/discord/slash/bank.rs
+++ b/bin/bot/src/discord/slash/bank.rs
@@ -6,7 +6,7 @@ use serenity::{
 use synixe_events::gear::db::Response;
 use synixe_meta::discord::{
     channel::LOG,
-    role::{ACTIVE, JUNIOR, MEMBER, STAFF},
+    role::{ACTIVE, STAFF},
     BRODSKY, GUILD,
 };
 use synixe_proc::events_request_2;


### PR DESCRIPTION
check to see if the user transferring money is at least a junior member and is active.