### PR TITLE
client/gear: readonly balance show both costs

### DIFF
--- a/arma/client/addons/gear/functions/fnc_shop_pfh_balance.sqf
+++ b/arma/client/addons/gear/functions/fnc_shop_pfh_balance.sqf
@@ -28,9 +28,11 @@ if (_invalid isNotEqualTo []) exitWith {
 private _cost = [_items] call FUNC(shop_items_cost);
 
 if (GVAR(readOnly) || EGVAR(campaigns,loadouts)) exitWith {
+    private _personal = [_items, 0] call FUNC(shop_items_cost);
+    private _company = [_items, 1] call FUNC(shop_items_cost);
     _btnHide ctrlEnable false;
-    _btnHide ctrlSetText format ["%1", _cost];
-    _btnHide ctrlSetTooltip "Loadout Cost";
+    _btnHide ctrlSetText format ["%1 + %2", _personal, _company];
+    _btnHide ctrlSetTooltip "Loadout Personal + Company";
 };
 
 if (_cost == 0) then {


### PR DESCRIPTION
This is to make the cost button make more sense on readOnly (training) mode

I currently set it to personal + company but personal / total also would seem valid

<img width="1920" height="1200" alt="image" src="https://github.com/user-attachments/assets/c9efce92-54c1-4cc6-b402-68eb75657215" />
